### PR TITLE
Make lines private to hide implementation

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1,3 +1,4 @@
+use std::cmp;
 use std::io::Error;
 
 use termion::event::Key;
@@ -7,7 +8,7 @@ use file::*;
 
 #[derive(Debug)]
 pub struct Editor {
-    pub lines: Vec<String>,
+    lines: Vec<String>,
     pub cursor: CursorPosition,
 }
 
@@ -17,6 +18,24 @@ impl Editor {
             lines,
             cursor: CursorPosition::new(),
         }
+    }
+
+    pub fn get_editor_lines(&self, terminal_height: usize) -> &[String] {
+        let y_offset = (self.cursor.y_offset) as usize;
+        let number_of_lines = self.get_number_of_lines();
+        let max_line = cmp::min(
+            number_of_lines,
+            terminal_height as usize + y_offset as usize,
+        );
+        self.get_range_lines(y_offset, max_line)
+    }
+
+    fn get_range_lines(&self, start: usize, stop: usize) -> &[String] {
+        &self.lines[start..stop]
+    }
+
+    pub fn get_number_of_lines(&self) -> usize {
+        self.lines.len()
     }
 
     pub fn insert(&mut self, c: char, terminal_height: u16) {
@@ -146,6 +165,7 @@ mod tests {
         assert_eq!(editor.lines.len(), 1);
         assert_eq!(editor.lines[0], "t");
         assert_eq!(editor.lines[0], "t");
+        assert_eq!(editor.get_number_of_lines(), 1);
     }
 
     #[test]
@@ -207,6 +227,9 @@ mod tests {
         assert_eq!(editor.cursor.x, 1);
         assert_eq!(editor.cursor.y, 2);
         assert_eq!(editor.cursor.y_offset, 0);
+        assert_eq!(editor.get_number_of_lines(), 2);
+        assert_eq!(editor.get_editor_lines(20), &vec!["this is a test", ""][..]);
+        assert_eq!(editor.get_editor_lines(1), &vec!["this is a test"][..]);
     }
 
     #[test]

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,6 +1,5 @@
 extern crate termion;
 
-use std::cmp;
 use std::io::Write;
 
 use termion::{color, style};
@@ -51,13 +50,11 @@ pub fn get_number_of_chars_of_u16(num: u16) -> u16 {
 
 pub fn print_text<W: Write>(stream: &mut W, editor: &Editor) {
     let (terminal_width, terminal_height) = termion::terminal_size().unwrap();
-    let left_pad = get_number_of_chars_of_u16(editor.lines.len() as u16);
-    let max_line = cmp::min(
-        editor.lines.len(),
-        terminal_height as usize - 1 + editor.cursor.y_offset as usize,
-    );
+    let number_of_lines = editor.get_number_of_lines();
+    let left_pad = get_number_of_chars_of_u16(number_of_lines as u16);
     let white_line = (0..terminal_width).map(|_| ' ').collect::<String>();
-    for (index, l) in editor.lines[editor.cursor.y_offset as usize..max_line]
+    for (index, l) in editor
+        .get_editor_lines(terminal_height as usize - 1)
         .iter()
         .enumerate()
     {
@@ -74,11 +71,11 @@ pub fn print_text<W: Write>(stream: &mut W, editor: &Editor) {
         )
     }
 
-    if editor.lines.len() < terminal_height as usize - 1 {
+    if number_of_lines < terminal_height as usize - 1 {
         write!(
             stream,
             "{}{}{}",
-            termion::cursor::Goto(1, editor.lines.len() as u16 + 2),
+            termion::cursor::Goto(1, number_of_lines as u16 + 2),
             white_line,
             termion::cursor::Goto(left_pad + editor.cursor.x + 2, editor.cursor.y + 1),
         )


### PR DESCRIPTION
This is necessery work if we want to change the storage of the text of our editor.